### PR TITLE
removed the ":syntax" argument from "use Dancer2;"

### DIFF
--- a/lib/Dancer2/Plugin/Adapter.pm
+++ b/lib/Dancer2/Plugin/Adapter.pm
@@ -7,7 +7,7 @@ package Dancer2::Plugin::Adapter;
 # VERSION
 
 use Dancer2::Plugin;
-use Dancer2 ':syntax';
+use Dancer2;
 use Class::Load qw/try_load_class/;
 
 my %singletons;

--- a/t/www-postmark.t
+++ b/t/www-postmark.t
@@ -24,7 +24,7 @@ test_tcp(
   server => sub {
     my $port = shift;
 
-    use Dancer2 ':syntax';
+    use Dancer2;
     use Dancer2::Plugin::Adapter;
 
     set confdir => '.';


### PR DESCRIPTION
Removing the ":syntax" argument on the "use Dancer2" line seems to do the trick for issue #2. All the tests pass now.

It doesn't do what I hoped it would in my web app, though. It might be because I misunderstood what a D2::P::Adapter singleton is. I'm trying to run a bot as a RESTful webservice through Dancer, in order to interact with it from the browser. I describe what I'm trying to do here, if you're curious: http://lists.preshweb.co.uk/pipermail/dancer-users/2013-December/003539.html
I tried to replace $bot by service('bot') (as a singleton), but it doesn't do the trick: I still have to re-login each time.

I will try and use Bread::Board.
