### PR TITLE
Update to work with recent D2 releases

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,7 @@ stopwords = de
 
 [Prereqs / Recommends]
 Class::Load::XS = 0
+Dancer2 = 0.153000
 
 [Prereqs / TestRecommends]
 WWW::Postmark = 0

--- a/dist.ini
+++ b/dist.ini
@@ -7,7 +7,8 @@ copyright_year   = 2012
 [@DAGOLDEN]
 :version = 0.032
 AutoMetaResources.bugtracker.rt = 0
-AutoMetaResources.bugtracker.github = user:dagolden
+AutoMetaResources.bugtracker.github = user:PerlDancer
+AutoMetaResources.repository.github = user:PerlDancer
 stopwords = Blabos
 stopwords = Blebe
 stopwords = de

--- a/t/http-tiny.t
+++ b/t/http-tiny.t
@@ -3,53 +3,44 @@ use warnings;
 use Test::More 0.96 import => ['!pass'];
 
 use HTTP::Tiny;
-use Test::TCP;
+use Plack::Test;
+use HTTP::Request::Common;
 
 HTTP::Tiny->new->get("http://google.com/")->{success}
   or plan skip_all => "google.com not available";
 
-test_tcp(
-  client => sub {
-    my $port = shift;
-    my $ua  = HTTP::Tiny->new;
-    my $res = $ua->get("http://localhost:$port/proxy");
-    ok( $res->{success}, "Request success" );
-    like $res->{content}, qr/google/i, "HTTP::Tiny got proxy response";
-  },
-  server => sub {
-    my $port = shift;
+{
+  package Test::Adapter::HttpTiny;
+  use Dancer2;
+  use Dancer2::Plugin::Adapter;
 
-    use Dancer2;
-    use Dancer2::Plugin::Adapter;
+  set show_errors => 1;
 
-    set confdir => '.';
-    set port => $port, startup_info => 0;
-
-    set show_errors => 1;
-
-    set plugins => {
-      Adapter => {
-        http => {
-          class   => 'HTTP::Tiny',
-          options => { max_redirect => 10 },
-        },
+  set plugins => {
+    Adapter => {
+      http => {
+        class   => 'HTTP::Tiny',
+        options => { max_redirect => 10 },
       },
-    };
+    },
+  };
 
-    get '/' => sub {
-      diag "in /";
-      return "Hello World";
-    };
+  get '/' => sub {
+    ::diag "in /";
+    return "Hello World";
+  };
 
-    get '/proxy' => sub {
-      my $response = service("http")->get("http://google.com/");
-      return $response->{content};
-    };
+  get '/proxy' => sub {
+    my $response = service("http")->get("http://google.com/");
+    return $response->{content};
+  };
+}
 
-    Dancer2->runner->server->port($port);
-    start;
-  },
-);
+my $test = Plack::Test->create( Test::Adapter::HttpTiny->to_app );
+
+my $res = $test->request( GET '/proxy');
+ok $res->is_success, "Request success";
+like $res->content, qr/google/i, "HTTP::Tiny got proxy response";
 
 done_testing;
 # COPYRIGHT

--- a/t/scopes.t
+++ b/t/scopes.t
@@ -2,21 +2,61 @@ use strict;
 use warnings;
 use Test::More 0.96 import => ['!pass'];
 
+use Plack::Test;
+use HTTP::Request::Common;
+use HTTP::Cookies;
+
 use File::Temp 0.19; # newdir
-use LWP::UserAgent;
 use JSON;
-use Test::TCP;
 
-test_tcp(
-  client => sub {
-    my $port = shift;
-    my $url  = "http://localhost:$port/";
+{
+  package Test::Adapter::Scopes;
+  use Dancer2;
+  use Dancer2::Plugin::Adapter;
 
-    my $ua  = LWP::UserAgent->new( cookie_jar => {} );
-    my $ua2 = LWP::UserAgent->new( cookie_jar => {} );
+  set show_errors => 1;
+  set serializer  => 'JSON';
+  set session => 'Simple';
+
+  set plugins => {
+    Adapter => {
+      singleton_tempdir => {
+        class       => 'File::Temp',
+        constructor => 'newdir',
+        scope       => 'singleton',
+      },
+      request_tempdir => {
+        class       => 'File::Temp',
+        constructor => 'newdir',
+        scope       => 'request',
+      },
+      none_tempdir => {
+        class       => 'File::Temp',
+        constructor => 'newdir',
+        scope       => 'none',
+      },
+    },
+  };
+
+  get '/' => sub {
+    return {
+      singleton    => "" . service("singleton_tempdir"),
+      request      => "" . service("request_tempdir"),
+      request_copy => "" . service("request_tempdir"),
+      fresh        => "" . service("none_tempdir"),
+      fresh_copy   => "" . service("none_tempdir"),
+    };
+  };
+}
+
+my $test = Plack::Test->create( Test::Adapter::Scopes->to_app );
+my $jar = HTTP::Cookies->new();
+my $jar2 = HTTP::Cookies->new();
+
+my $url = 'http://localhost/';
 
     # first request
-    my $first = eval { from_json( $ua->get($url)->content ) };
+    my $first = eval { from_json( test_request($url, $jar)->content ) };
     diag $@ if $@;
     is(
       $first->{request},
@@ -27,7 +67,7 @@ test_tcp(
       "no-scope services vary within request" );
 
     # second request, same session
-    my $second = eval { from_json( $ua->get($url)->content ) };
+    my $second = eval { from_json( test_request($url, $jar)->content ) };
     diag $@ if $@;
     is( $first->{singleton}, $second->{singleton},
       "singleton scope preserved across requests" );
@@ -35,60 +75,22 @@ test_tcp(
       "request scope varies across requests" );
 
     # third request, different session
-    my $third = eval { from_json( $ua2->get($url)->content ) };
+    my $third = eval { from_json( test_request($url, $jar2)->content ) };
     diag $@ if $@;
     is( $first->{singleton}, $third->{singleton},
       "singleton scope preserved across sessions" );
 
-  },
-
-  server => sub {
-    my $port = shift;
-
-    use Dancer2;
-    use Dancer2::Plugin::Adapter;
-
-    set confdir => '.';
-    set port    => $port, startup_info => 0;
-
-    set show_errors => 1;
-    set serializer  => 'JSON';
-    set session => 'Simple';
-
-    set plugins => {
-      Adapter => {
-        singleton_tempdir => {
-          class       => 'File::Temp',
-          constructor => 'newdir',
-          scope       => 'singleton',
-        },
-        request_tempdir => {
-          class       => 'File::Temp',
-          constructor => 'newdir',
-          scope       => 'request',
-        },
-        none_tempdir => {
-          class       => 'File::Temp',
-          constructor => 'newdir',
-          scope       => 'none',
-        },
-      },
-    };
-
-    get '/' => sub {
-      return {
-        singleton    => "" . service("singleton_tempdir"),
-        request      => "" . service("request_tempdir"),
-        request_copy => "" . service("request_tempdir"),
-        fresh        => "" . service("none_tempdir"),
-        fresh_copy   => "" . service("none_tempdir"),
-      };
-    };
-
-    Dancer2->runner->server->port($port);
-    start;
-  },
-);
-
 done_testing;
+
+sub test_request {
+    my ($url, $jar) = @_;
+    my $req = GET($url);
+    $jar->add_cookie_header($req);
+
+    my $res = $test->request($req);
+    $jar->extract_cookies($res);
+
+    return $res;
+}
+
 # COPYRIGHT

--- a/t/www-postmark.t
+++ b/t/www-postmark.t
@@ -2,62 +2,53 @@ use strict;
 use warnings;
 use Test::More 0.96 import => ['!pass'];
 
+use HTTP::Tiny;
+use Plack::Test;
+use HTTP::Request::Common;
+
 use Class::Load qw/try_load_class/;
-use Test::TCP;
 try_load_class('WWW::Postmark')
   or plan skip_all => "WWW::Postmark required to run these tests";
 
 HTTP::Tiny->new->get("http://api.postmarkapp.com/")->{success}
   or plan skip_all => "api.postmarkapp.com not available";
 
-test_tcp(
-  client => sub {
-    my $port = shift;
-    my $url  = "http://localhost:$port/";
+{
+  package Test::Adapter::WWWPostmark;
+  use Dancer2 ':syntax';
+  use Dancer2::Plugin::Adapter;
 
-    my $ua  = HTTP::Tiny->new;
-    my $res = $ua->get($url);
-    ok( $res->{success}, "Request success" );
-    like $res->{content}, qr/Mail sent/i, "WWW::Postmark pretended to send mail";
-  },
+  set show_errors => 0;
 
-  server => sub {
-    my $port = shift;
-
-    use Dancer2 ':syntax';
-    use Dancer2::Plugin::Adapter;
-
-    set confdir => '.';
-    set port => $port, startup_info => 0;
-
-    set show_errors => 0;
-
-    set plugins => {
-      Adapter => {
-        postmark => {
-          class   => 'WWW::Postmark',
-          options => 'POSTMARK_API_TEST',
-        },
+  set plugins => {
+    Adapter => {
+      postmark => {
+        class   => 'WWW::Postmark',
+        options => 'POSTMARK_API_TEST',
       },
+    },
+  };
+
+  get '/' => sub {
+    eval {
+      service("postmark")->send(
+        from    => 'me@domain.tld',
+        to      => 'you@domain.tld, them@domain.tld',
+        subject => 'an email message',
+        body    => "hi guys, what's up?"
+      );
     };
 
-    get '/' => sub {
-      eval {
-        service("postmark")->send(
-          from    => 'me@domain.tld',
-          to      => 'you@domain.tld, them@domain.tld',
-          subject => 'an email message',
-          body    => "hi guys, what's up?"
-        );
-      };
+    return $@ ? "Error: $@" : "Mail sent";
+  };
 
-      return $@ ? "Error: $@" : "Mail sent";
-    };
+}
 
-    Dancer2->runner->server->port($port);
-    start;
-  },
-);
+my $test = Plack::Test->create( Test::Adapter::WWWPostmark->to_app );
+
+my $res = $test->request( GET '/' );
+ok $res->is_success, "Request success";
+like $res->content, qr/Mail sent/i, "WWW::Postmark pretended to send mail";
 
 done_testing;
 # COPYRIGHT


### PR DESCRIPTION
Allows plugin to work with Dancer2 v0.153+ (now the minimum specified version in `dist.ini`)

Updates this plugin to use `$dsl->var` to silence the "DEPRECATED" warning and rework the test suite to use Plack::Test.

Resolves #1 and #2. Pr #3 is no longer required after this is applied.
